### PR TITLE
add global for node support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var document = require('global/document')
 
 module.exports = function load (src, opts, cb) {
   var head = document.head || document.getElementsByTagName('head')[0]

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "devDependencies": {
     "zuul": "~2.1.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "global": "~4.3.2"
+  }
 }


### PR DESCRIPTION
This fixes a bug where `document` is not defined on a server, therefore referencing `document.` will throw an error. 

An example use case would be using a server side rendered react application, you get this:

![](http://d.pr/i/pbgHIg+)